### PR TITLE
Pin GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,14 +10,14 @@ jobs:
   build:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       with:
         fetch-depth: 0
     - name: Read .nvmrc
       run: echo ::set-output name=NVMRC::$(cat .nvmrc)  # see: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#set-an-output-parameter-set-output
       id: nvm
     - name: Set up node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
       with:
         node-version: "${{ steps.nvm.outputs.NVMRC }}"
     - name: Cache npm
@@ -28,14 +28,14 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Cache pip
-      uses: actions/cache@v1
+      uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/Pipfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-pip-
     - run: npm ci
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@0f07f7f756721ebd886c2462646a35f78a8bc4de # v1
       with:
         python-version: '3.9'
     - name: Setup pipenv

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         node-version: "${{ steps.nvm.outputs.NVMRC }}"
     - name: Cache npm
-      uses: actions/cache@v1
+      uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/forked-pr-deploy.yml
+++ b/.github/workflows/forked-pr-deploy.yml
@@ -12,10 +12,10 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
       - name: Checkout
         if: "endsWith(github.event.context, 'ci/circleci: build') && github.event.state == 'success'"
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Setup Python
         if: "endsWith(github.event.context, 'ci/circleci: build') && github.event.state == 'success'"
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@0f07f7f756721ebd886c2462646a35f78a8bc4de # v1
         with:
           python-version: '3.9'
       - name: Download Build
@@ -29,7 +29,7 @@ jobs:
           pipenv run ./content-repo/download_site_builid.py -e "$GITHUB_EVENT_PATH"
       - name: Setup Node
         if: "steps.build_download.outputs.forked_pr > 0"
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: '12.x'  
 #      - name: Deploy Netlify Build

--- a/.github/workflows/links-verify.yml
+++ b/.github/workflows/links-verify.yml
@@ -18,7 +18,7 @@ jobs:
         fetch-depth: 0
         ref: 'master'
     - name: content-docs checkout
-      uses: actions/checkout@v2.4.0  # https://github.com/marketplace/actions/checkout
+      uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0  # https://github.com/marketplace/actions/checkout
       with:
         repository: demisto/content-docs
         path: content-docs
@@ -35,7 +35,7 @@ jobs:
         cat content-docs/urls_ignore.txt >> all_urls_ignore.txt
         cat all_urls_ignore.txt
     - name: Set up Go 1.13
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
       with:
         go-version: 1.13.11
       id: go
@@ -56,7 +56,7 @@ jobs:
         echo "All good! muffet passed!!!"
     - name: Save artifcats
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
       with:
         name: log-artifacts
         path: muffet.txt

--- a/.github/workflows/links-verify.yml
+++ b/.github/workflows/links-verify.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: content checkout
-      uses: actions/checkout@v2.4.0  # https://github.com/marketplace/actions/checkout
+      uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0  # https://github.com/marketplace/actions/checkout
       with:
         repository: demisto/content
         path: content


### PR DESCRIPTION
GitHub recommends pinning actions to a full length commit SHA, as this is currently the only method of using an action as an immutable release.

For more information refer to: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions